### PR TITLE
Add Microbiology and PGT test cases

### DIFF
--- a/novaseq-x-automation-cron.py
+++ b/novaseq-x-automation-cron.py
@@ -129,7 +129,7 @@ def main():
                         job_id = start_nsc_nextflow(project_name, run_id, suffix, delivery_method, demultiplexed_run_dir, is_paired_end, is_onboard, is_ora, bcl_convert_version)
                         nsc_project_slurm_jobs.append(job_id)
                     elif project_type == "Microbiology":
-                        start_human_removal(run_id, project_dir_name, project_samples)
+                        start_human_removal(run_id, project_name, project_samples)
                     elif project_type == "PGT":
                         progress_logger.info(f"No additional actions required for PGT project {project_name}.")
                     else:
@@ -228,7 +228,7 @@ def start_human_removal(run_id, project_name, project_samples):
     script_path = "/data/runScratch.boston/mik_data/human_cleanup_analysis/mik_cleanup_script.sh"
     for sample in project_samples:
         # Start one human removal job per sample
-        mik_sample_id = f"{sample['sample_name']}_S{sample['samplesheet_position']}_L{str(s.lane).zfill(3)}"
+        mik_sample_id = f"{sample['sample_name']}_S{sample['samplesheet_position']}_L{str(sample['lane']).zfill(3)}"
         subprocess.run(
             ["sbatch", str(script_path), mik_sample_id],
             cwd=project_dir,

--- a/tests/test_novaseqx.py
+++ b/tests/test_novaseqx.py
@@ -66,6 +66,95 @@ samples:
 status: ImportCompleted
 """
 
+# YAML including additional Microbiology and PGT project types
+EXAMPLE_YAML_EXTRA_TYPES = """bcl_convert_version: 4.3.16
+compute_platform: Onboard DRAGEN
+demultiplexing_process_id: 24-1081653
+run_id: 20250502_LH00534_0135_B22LCYYLT4
+samples:
+- artifact_id: 2-4950921
+  artifact_name: 188-450
+  delivery_method: TSD project
+  lane: 1
+  lane_artifact: 2-4976860
+  num_data_read_passes: 2
+  onboard_workflow: bcl_convert
+  ora_compression: false
+  output_artifact_id: 92-4976795
+  project_id: DAH12001
+  project_name: Christophersen-DNA2-2025-04-10
+  project_type: Sensitive
+  sample_id: DAH12001A188
+  sample_name: 188-450
+  samplesheet_position: 140
+  samplesheet_sample_id: 188-450_2-4950921
+- artifact_id: 2-4950789
+  artifact_name: 156-416
+  delivery_method: TSD project
+  lane: 1
+  lane_artifact: 2-4976860
+  num_data_read_passes: 2
+  onboard_workflow: bcl_convert
+  ora_compression: false
+  output_artifact_id: 92-4976796
+  project_id: DAH12001
+  project_name: Christophersen-DNA2-2025-04-10
+  project_type: Sensitive
+  sample_id: DAH12001A156
+  sample_name: 156-416
+  samplesheet_position: 108
+  samplesheet_sample_id: 156-416_2-4950789
+- artifact_id: 2-4950912
+  artifact_name: 179-441
+  delivery_method: TSD project
+  lane: 1
+  lane_artifact: 2-4976860
+  num_data_read_passes: 2
+  onboard_workflow: bcl_convert
+  ora_compression: false
+  output_artifact_id: 92-4976797
+  project_id: DAH12001
+  project_name: Hei-DNA2-2025-04-10
+  project_type: Sensitive
+  sample_id: DAH12001A179
+  sample_name: 179-441
+  samplesheet_position: 131
+  samplesheet_sample_id: 179-441_2-4950912
+- artifact_id: 2-9999999
+  artifact_name: MIK-S1
+  delivery_method: Standard
+  lane: 1
+  lane_artifact: 2-4976860
+  num_data_read_passes: 2
+  onboard_workflow: bcl_convert
+  ora_compression: false
+  output_artifact_id: 92-9999999
+  project_id: MIK1001
+  project_name: Microbio-2025-04-10
+  project_type: Microbiology
+  sample_id: MIK1001A1
+  sample_name: MIK-S1
+  samplesheet_position: 150
+  samplesheet_sample_id: MIK-S1_2-9999999
+- artifact_id: 2-8888888
+  artifact_name: PGT-S1
+  delivery_method: TSD project
+  lane: 1
+  lane_artifact: 2-4976860
+  num_data_read_passes: 2
+  onboard_workflow: bcl_convert
+  ora_compression: false
+  output_artifact_id: 92-8888888
+  project_id: PGT0001
+  project_name: PGT-Project-2025-04-10
+  project_type: PGT
+  sample_id: PGT0001A1
+  sample_name: PGT-S1
+  samplesheet_position: 160
+  samplesheet_sample_id: PGT-S1_2-8888888
+status: ImportCompleted
+"""
+
 def create_example_run(tmpdir: Path, yaml_text: str):
     run_id = "20250502_LH00534_0135_B22LCYYLT4"
     run_dir = tmpdir / run_id
@@ -132,6 +221,19 @@ class FileMoverTest(unittest.TestCase):
             self.assertTrue(p.fastq_path.is_dir())
             self.assertTrue(p.qc_path.is_dir())
 
+    def test_run_creates_directories_extra_types(self):
+        shutil.rmtree(self.run_dir)
+        self.run_dir, self.analysis_dir = create_example_run(self.tmpdir, EXAMPLE_YAML_EXTRA_TYPES)
+        mover = self.fm_mod.FileMover(self.analysis_dir, self.fm_mod.DEST_PATHS)
+        with patch("os.link"):
+            mover.run()
+        project_types = {p.project_type for p in mover.projects.values()}
+        self.assertIn("Microbiology", project_types)
+        self.assertIn("PGT", project_types)
+        for p in mover.projects.values():
+            self.assertTrue(p.fastq_path.is_dir())
+            self.assertTrue(p.qc_path.is_dir())
+
 class AutomationCronTest(unittest.TestCase):
     def setUp(self):
         self.tmpdir = Path(tempfile.mkdtemp())
@@ -162,6 +264,27 @@ class AutomationCronTest(unittest.TestCase):
             sprun.return_value = subprocess.CompletedProcess(["sbatch"], 0, stdout=b"1")
             self.ac_mod.main()
         self.assertTrue(any("novaseq-x-file-mover.py" in c[1] for c in calls))
+
+    def test_main_handles_extra_project_types(self):
+        shutil.rmtree(self.run_dir)
+        self.run_dir, self.analysis_dir = create_example_run(self.tmpdir, EXAMPLE_YAML_EXTRA_TYPES)
+        calls = []
+        human_calls = []
+        def fake_run(logger, args, **kw):
+            calls.append(args)
+            return None
+        def fake_human(*a, **kw):
+            human_calls.append(a)
+        with patch.object(self.ac_mod, "run_subprocess_with_logging", side_effect=fake_run), \
+             patch.object(self.ac_mod, "start_nsc_nextflow", return_value="1") as nextflow, \
+             patch.object(self.ac_mod, "start_human_removal", side_effect=fake_human), \
+             patch.object(self.ac_mod.subprocess, "run") as sprun:
+            sprun.return_value = subprocess.CompletedProcess(["sbatch"], 0, stdout=b"1")
+            self.ac_mod.main()
+        self.assertTrue(any("novaseq-x-file-mover.py" in c[1] for c in calls))
+        self.assertEqual(len(human_calls), 1)
+        # Only NSC projects should trigger nextflow
+        self.assertEqual(nextflow.call_count, 2)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- extend novaseq-x test data to include Microbiology and PGT project types
- add FileMover and automation cron tests for the additional project types
- fix Microbiology automation bug (use project name when calling human removal)

## Testing
- `pytest -q tests/test_novaseqx.py`
- `PYTHONPATH=. pytest -q` *(fails: FileNotFoundError for missing sample data)*


------
https://chatgpt.com/codex/tasks/task_e_685020df8d9c83289e7f2070e21ef5a5